### PR TITLE
Downgrade noisy registration log messages from INFO to DEBUG

### DIFF
--- a/dj_control_room/admin_integration.py
+++ b/dj_control_room/admin_integration.py
@@ -146,6 +146,6 @@ def _register_panel_admin(panel):
     # Register it with the admin site
     admin.site.register(model_class, admin_class)
 
-    logger.info(
+    logger.debug(
         f"Registered admin entry for panel '{panel._registry_id}' ({panel.name})"
     )

--- a/dj_control_room/registry.py
+++ b/dj_control_room/registry.py
@@ -118,7 +118,7 @@ class PanelRegistry:
             return
 
         self._panels[panel_id] = panel
-        logger.info(f"Registered panel '{panel_id}' ({panel.name})")
+        logger.debug(f"Registered panel '{panel_id}' ({panel.name})")
 
     def _verify_featured_identity(self, panel_id, entry_point):
         """
@@ -247,7 +247,7 @@ class PanelRegistry:
             return
 
         self._panels[panel_id] = panel
-        logger.info(f"Manually registered panel '{panel_id}' ({panel.name})")
+        logger.debug(f"Manually registered panel '{panel_id}' ({panel.name})")
     
     def get_panels(self):
         """


### PR DESCRIPTION
## Summary

- Panel and admin registration success messages were logged at `INFO` level, causing them to appear in stdout on every server startup
- Downgraded these to `DEBUG` so they only surface when explicitly debugging

Fixes #5

## Test plan

- [ ] Start a Django project with dj-control-room installed and confirm registration messages no longer appear in stdout
- [ ] Set the `dj_control_room` logger to `DEBUG` and confirm the messages do still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)